### PR TITLE
Add fix for TLS PEM encoded root certs on Windows platform

### DIFF
--- a/Source/TurboLinkGrpc/Private/TurboLinkGrpcManager_Private.cpp
+++ b/Source/TurboLinkGrpc/Private/TurboLinkGrpcManager_Private.cpp
@@ -51,8 +51,20 @@ std::shared_ptr<UTurboLinkGrpcManager::Private::ServiceChannel> UTurboLinkGrpcMa
 	//is server-side tls mode?
 	if (config->EnableServerSideTLS)
 	{
+		FString ServerRootCerts = config->GetServerRootCerts();
+		
 		grpc::SslCredentialsOptions ssl_opts;
-		ssl_opts.pem_root_certs = TCHAR_TO_UTF8(*(config->GetServerRootCerts()));
+		ssl_opts.pem_root_certs = TCHAR_TO_UTF8(*ServerRootCerts);
+
+		// If we are on Windows, we need to fetch the root certificates from the system registry
+		// otherwise grpc source will try to default to a linux system path that doesn't exist
+#if PLATFORM_WINDOWS
+		if (ServerRootCerts.IsEmpty())
+		{
+			ssl_opts = getSslOptions();
+		}
+#endif
+		
 		channel->RpcChannel = grpc::CreateCustomChannel(EndPoint, grpc::SslCredentials(ssl_opts), args);
 	}
 	else
@@ -115,3 +127,42 @@ void UTurboLinkGrpcManager::Private::ShutdownCompletionQueue()
 	}
 }
 
+grpc::SslCredentialsOptions UTurboLinkGrpcManager::Private::getSslOptions()
+{
+	// Fetch root certificate as required on Windows (s. issue 25533).
+	grpc::SslCredentialsOptions result;
+
+	// Open root certificate store.
+	HANDLE hRootCertStore = CertOpenSystemStoreW(NULL, L"ROOT");
+	if (!hRootCertStore)
+		return result;
+
+	// Get all root certificates.
+	PCCERT_CONTEXT pCert = NULL;
+	while ((pCert = CertEnumCertificatesInStore(hRootCertStore, pCert)) != NULL)
+	{
+		// Append this certificate in PEM formatted data.
+		DWORD size = 0;
+		CryptBinaryToStringW(pCert->pbCertEncoded, pCert->cbCertEncoded, CRYPT_STRING_BASE64HEADER,
+			NULL, &size);
+		std::vector<WCHAR> pem(size);
+		CryptBinaryToStringW(pCert->pbCertEncoded, pCert->cbCertEncoded, CRYPT_STRING_BASE64HEADER,
+			pem.data(), &size);
+
+		result.pem_root_certs += utf8Encode(pem.data());
+	}
+
+	CertCloseStore(hRootCertStore, 0);
+	return result;
+}
+
+std::string UTurboLinkGrpcManager::Private::utf8Encode(const std::wstring& wstr)
+{
+	if (wstr.empty())
+		return std::string();
+
+	int sizeNeeded = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
+	std::string strTo(sizeNeeded, 0);
+	WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], sizeNeeded, NULL, NULL);
+	return strTo;
+}

--- a/Source/TurboLinkGrpc/Private/TurboLinkGrpcManager_Private.cpp
+++ b/Source/TurboLinkGrpc/Private/TurboLinkGrpcManager_Private.cpp
@@ -127,6 +127,7 @@ void UTurboLinkGrpcManager::Private::ShutdownCompletionQueue()
 	}
 }
 
+#if PLATFORM_WINDOWS
 grpc::SslCredentialsOptions UTurboLinkGrpcManager::Private::getSslOptions()
 {
 	// Fetch root certificate as required on Windows (s. issue 25533).
@@ -166,3 +167,4 @@ std::string UTurboLinkGrpcManager::Private::utf8Encode(const std::wstring& wstr)
 	WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], sizeNeeded, NULL, NULL);
 	return strTo;
 }
+#endif

--- a/Source/TurboLinkGrpc/Private/TurboLinkGrpcManager_Private.h
+++ b/Source/TurboLinkGrpc/Private/TurboLinkGrpcManager_Private.h
@@ -36,6 +36,9 @@ public:
 
 	void ShutdownCompletionQueue();
 
+	static grpc::SslCredentialsOptions getSslOptions();
+	static std::string utf8Encode(const std::wstring& wstr);
+
 public:
 	std::map<std::string, std::shared_ptr<ServiceChannel>> ChannelMap;
 	std::unique_ptr<grpc::CompletionQueue> CompletionQueue;

--- a/Source/TurboLinkGrpc/Private/TurboLinkGrpcManager_Private.h
+++ b/Source/TurboLinkGrpc/Private/TurboLinkGrpcManager_Private.h
@@ -36,8 +36,10 @@ public:
 
 	void ShutdownCompletionQueue();
 
+#if PLATFORM_WINDOWS
 	static grpc::SslCredentialsOptions getSslOptions();
 	static std::string utf8Encode(const std::wstring& wstr);
+#endif
 
 public:
 	std::map<std::string, std::shared_ptr<ServiceChannel>> ChannelMap;


### PR DESCRIPTION
If using TLS with no set certificates in `pem_root_certs`, GRPC libs will attempt to populate `pem_root_certs` with default certificates on the system. The issue arises from the library attempting to use a Linux file path, even when on the Windows platform.

This has been fixed by pulling certificates from the system registry when on the Windows platform and no certificate has been manually set in the config.